### PR TITLE
Template query function missing results

### DIFF
--- a/src/debby/pools.nim
+++ b/src/debby/pools.nim
@@ -155,7 +155,7 @@ template query*(pool: Pool, sql: string, args: varargs[Argument, toArgument]): s
   ## Query returning plain results
   var data: seq[Row]
   pool.withDb:
-    db.query(sql, args)
+    data = db.query(sql, args)
   data
 
 template query*[T](pool: Pool, t: typedesc[T], sql: string, args: varargs[Argument, toArgument]): seq[T] =


### PR DESCRIPTION
- Ran into this when doing `db.query("INSERT INTO...")` the template code was not setting the data var properly.
- `is of type 'seq[Row]' and has to be used (or discarded); start of expression here: /Users/{redacted}/src/debby/src/debby/pools.nim(157, 7)`